### PR TITLE
fix: remove item resource flag when item is deleted

### DIFF
--- a/scripts/ItemResources.js
+++ b/scripts/ItemResources.js
@@ -47,7 +47,25 @@ export class ItemResources {
 
   static preUpdateItemResources(item, updateData, options, userId) { }
   static createItemResources(item, updateData, options, userId) { }
-  static preDeleteItemResources(item, updateData, options, userId) { }
+
+  /**
+ * Pre-delete hook to handle cleanup of item resource flags when an item is deleted.
+ * @param {Item5e} item - The item being deleted.
+ * @param {Object} options - Options for the deletion.
+ * @param {string} userId - The ID of the user performing the deletion.
+ */
+  static async preDeleteItemResources(item, options, userId) {
+    const actor = item.parent;
+    if (!actor || !actor.flags?.dnd5eItemResources) return;
+
+    const itemId = item.id;
+
+    if (actor.flags.dnd5eItemResources.hasOwnProperty(itemId)) {
+      await actor.update({
+        [`flags.dnd5eItemResources.-=${itemId}`]: null
+      });
+    }
+  }
 
   /**
    * Pre-update hook to handle item resource updates.


### PR DESCRIPTION
fix: remove resource bar flag when item is deleted

Previously, when an item with an active resource bar was deleted from an actor, its configuration remained in the actor's flags under `dnd5eItemResources`. This caused leftover bars to appear on the character sheet even though the item no longer existed.

This commit adds a `preDeleteItem` hook to clean up the corresponding flag, ensuring that the resource bar is removed properly when the item is deleted.